### PR TITLE
Clean todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ where:
 
 - `model` is any of the following: `ae`, `arm`, `avb`, `bigan`, `ebm`, `flow`, `vae`, or `wae`
 - `dataset` is any of the datasets listed in the `main.py` usage
-- `--is-gae` is a flag that should be included when the model is a GAE, as it allows indexing the correct set of config files (__TODO__: Remove)
+- `--is-gae` is a flag that should be included when the model is a GAE, as it allows indexing the correct set of config files
 
 As with `main.py`, launching this command will produce a run directory containing the same elements as before.
 Also like `main.py`, `single_main.py` maintains the same behaviour for the following command line flags:
@@ -251,9 +251,3 @@ Locate the AVB+VAE folder trained using `main.py`:
 ### Acknowledgments
 
 We would like to acknowledge the [Continuously Indexed Flows](https://github.com/jrmcornish/cif) codebase for providing inspiration for several concepts in this codebase, including configs (including the dynamic command line update), run directories & checkpointing, data loading, and tensorboard writers.
-
-
-### Config Arguments
-
-__TODO__
-

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Assuming the pretrained GAE has run directory `runs/<gae-dir>`, this can be acco
 
 where `<de>` is any of the DE models listed above.
 
+**IMPORTANT NOTE:** The pretrained GAE *must* have been trained with the `--is-gae` flag if initially run by `single_main.py` so that the `main.py` command in this section properly picks up the config `gae_config.json`.
+
 We also often use the following tags described below:
 - `--load-best-valid-first`: Attempt to load the `best_valid` checkpoint from early stopping before the `latest` checkpoint.
 - `--freeze-pretrained-gae`: Freeze the weights of the pretrained GAE, i.e. *do not* train the pretrained GAE further.
@@ -142,7 +144,7 @@ where:
 
 - `model` is any of the following: `ae`, `arm`, `avb`, `bigan`, `ebm`, `flow`, `vae`, or `wae`
 - `dataset` is any of the datasets listed in the `main.py` usage
-- `--is-gae` is a flag that should be included when the model is a GAE, as it allows indexing the correct set of config files
+- `--is-gae` is a flag that should be included when the model is a GAE, as it allows indexing the correct set of config files and saves the config as JSON under the name `gae_config.json`
 
 As with `main.py`, launching this command will produce a run directory containing the same elements as before.
 Also like `main.py`, `single_main.py` maintains the same behaviour for the following command line flags:

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -38,7 +38,7 @@ def test_all_pretrained_gae(gae, de):
     # Test that training runs without error
     train_run = subprocess.run(
         ["python", "single_main.py"] + flags["one_step"] + model_flags(gae, train_type="one_step")
-        + ["--is-gae"] # TODO: remove line when flag is deprecated
+        + ["--is-gae"]
     )
     assert train_run.returncode == 0
 

--- a/two_step_zoo/density_estimator/flow.py
+++ b/two_step_zoo/density_estimator/flow.py
@@ -24,13 +24,12 @@ class NormalizingFlow(DensityEstimator):
         )
 
     def sample(self, n_samples):
-        # TODO: batch in parent class
         samples = self._nflow.sample(n_samples)
         return self._inverse_data_transform(samples)
 
     @batch_or_dataloader()
     def log_prob(self, x):
-        # TODO: Careful with log probability when using _data_transform()
+        # NOTE: Careful with log probability when using _data_transform()
         x = self._data_transform(x)
         log_prob = self._nflow.log_prob(x)
 

--- a/two_step_zoo/evaluators/metrics_helpers.py
+++ b/two_step_zoo/evaluators/metrics_helpers.py
@@ -10,7 +10,7 @@ class InceptionHelper():
         self.gt_loader = gt_loader
         self.gen_samples = gen_samples
         self.gen_batch_size = gen_batch_size
-        self.inception = fid_score.InceptionV3().to(module.device) # TODO: submodule pytorch_fid?
+        self.inception = fid_score.InceptionV3().to(module.device)
 
     def gen_loader(self):
         # TODO: consider refactoring this into a `sample_loader` method in TwoStepDensityEstimator

--- a/two_step_zoo/trainers/single_trainer.py
+++ b/two_step_zoo/trainers/single_trainer.py
@@ -284,7 +284,5 @@ class SingleTrainer(BaseTrainer):
         self.valid_loader = valid_loader
         self.test_loader = test_loader
 
-        # TODO: if there are problems with train_loader in evaluator, consider refactoring
-        #       evaluator to include train_loader as an attribute
         self.evaluator.valid_loader = valid_loader
         self.evaluator.test_loader = test_loader

--- a/two_step_zoo/writer.py
+++ b/two_step_zoo/writer.py
@@ -5,10 +5,8 @@ import os
 import datetime
 import json
 import sys
-
 import numpy as np
 import torch
-
 from tensorboardX import SummaryWriter
 
 
@@ -20,7 +18,6 @@ class Tee:
 
         self.encoding = self.primary_file.encoding
 
-    # TODO: Should redirect all attrs to primary_file if not found here.
     def isatty(self):
         return self.primary_file.isatty()
 

--- a/two_step_zoo/writer.py
+++ b/two_step_zoo/writer.py
@@ -1,10 +1,10 @@
 # NOTE: The below file is modified from commit `aeaf5fd` of
 #       https://github.com/jrmcornish/cif/blob/master/cif/writer.py
-
 import os
 import datetime
 import json
 import sys
+
 import numpy as np
 import torch
 from tensorboardX import SummaryWriter


### PR DESCRIPTION
This PR cleans deprecated TODOs and adds a bit more clarity about the `--is-gae` flag in `single_main.py`.

This PR passes the tests called via both `pytest` and `pytest -m cmd`. I have neglected to test `pytest -m cmd-exhaustive` since the changes here are very minor.